### PR TITLE
fix: Normalize local development baseurl to match production

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -443,11 +443,11 @@ learn-with-satya/
 # Install dependencies
 bundle install
 
-# Serve site locally with auto-rebuild
-bundle exec jekyll serve
+# Serve site locally with baseurl (matches production)
+bundle exec jekyll serve --baseurl /learn-with-satya
 
 # Serve with drafts and future posts
-bundle exec jekyll serve --drafts --future
+bundle exec jekyll serve --drafts --future --baseurl /learn-with-satya
 
 # Build for production
 JEKYLL_ENV=production bundle exec jekyll build

--- a/.github/skills/git-workflow-github-cli/SKILL.md
+++ b/.github/skills/git-workflow-github-cli/SKILL.md
@@ -120,6 +120,10 @@ bundle exec jekyll build --future
 # Check for build errors
 # Exit code 0 = success
 # Exit code 1 = errors
+
+# Test with local server (optional)
+bundle exec jekyll serve --future --baseurl /learn-with-satya
+# Visit: http://127.0.0.1:4000/learn-with-satya/
 ```
 
 ---

--- a/docs/BLOG-SYSTEM-GUIDE.md
+++ b/docs/BLOG-SYSTEM-GUIDE.md
@@ -748,7 +748,7 @@ _posts/
 
 3. **Post Layout:** Includes series-navigation.html component (already integrated)
 
-4. **Jekyll Rebuild:** Run `bundle exec jekyll serve` to regenerate
+4. **Jekyll Rebuild:** Run `bundle exec jekyll serve --baseurl /learn-with-satya` to regenerate
 
 ---
 
@@ -806,7 +806,7 @@ _posts/
 **Debug:**
 ```bash
 bundle exec jekyll build --trace  # Shows full error stack
-bundle exec jekyll serve --verbose  # Shows build warnings
+bundle exec jekyll serve --verbose --baseurl /learn-with-satya  # Shows build warnings
 ```
 
 ---
@@ -855,7 +855,7 @@ python scripts/blog/analyze_blog.py _posts/ai/my-post.md --format markdown
 
 ### Phase 5: Testing & Polish
 
-- [ ] **Test Build** - `bundle exec jekyll serve`
+- [ ] **Test Build** - `bundle exec jekyll serve --baseurl /learn-with-satya`
 - [ ] **Create Example Posts** - 1 per category (7 total)
 - [ ] **Test Series Navigation** - Create 3-part sample series
 - [ ] **Test Progress Tracking** - Verify localStorage, dashboard

--- a/docs/LOCAL-DEVELOPMENT.md
+++ b/docs/LOCAL-DEVELOPMENT.md
@@ -1,0 +1,58 @@
+# Local Development Setup
+
+## URL Normalization
+
+To ensure consistency between local development and production, always use the `--baseurl` flag when serving locally:
+
+### ✅ Correct Local Commands
+
+```bash
+# Standard serve (normalized URLs)
+bundle exec jekyll serve --baseurl /learn-with-satya
+
+# With future posts and drafts  
+bundle exec jekyll serve --drafts --future --baseurl /learn-with-satya
+
+# Package.json scripts (already updated)
+npm run serve  # Uses baseurl automatically
+npm run dev    # Uses baseurl automatically
+```
+
+### 🌐 URL Structure
+
+| Environment | URL Structure | Example |
+|-------------|---------------|---------|
+| **Local** | `localhost:4000/learn-with-satya/` | `http://localhost:4000/learn-with-satya/ai/transformer-architecture/` |
+| **Production** | `srisatyalokesh.is-a.dev/learn-with-satya/` | `https://srisatyalokesh.is-a.dev/learn-with-satya/ai/transformer-architecture/` |
+
+### 🔧 Configuration
+
+The site is configured with:
+- **baseurl**: `/learn-with-satya` (in `_config.yml`)  
+- **url**: `https://srisatyalokesh.is-a.dev` (production domain)
+
+### ❌ Common Issues
+
+**Problem**: Links work locally but break on GitHub Pages  
+**Cause**: Using localhost:4000/ instead of localhost:4000/learn-with-satya/  
+**Solution**: Always include `--baseurl /learn-with-satya` flag when serving
+
+**Problem**: Agents expect /learn-with-satya/ path locally  
+**Cause**: Baseurl mismatch between environments  
+**Solution**: Use normalized commands above for consistent behavior
+
+### 🚀 Quick Start
+
+```bash
+# Clone and setup
+git clone https://github.com/SriSatyaLokesh/learn-with-satya.git
+cd learn-with-satya
+bundle install
+
+# Serve with correct baseurl
+bundle exec jekyll serve --future --baseurl /learn-with-satya
+
+# Visit: http://localhost:4000/learn-with-satya/
+```
+
+This ensures your local development environment matches production exactly!

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -393,7 +393,7 @@ _data/
 # Complete action items:
 #   - Source hero image from Unsplash
 #   - Update _data/series.yml
-#   - Test locally: bundle exec jekyll serve
+#   - Test locally: bundle exec jekyll serve --baseurl /learn-with-satya
 #   - Commit and push
 
 # Done! Post published to GitHub Pages

--- a/docs/codebase/architecture.md
+++ b/docs/codebase/architecture.md
@@ -33,7 +33,7 @@ Learn with Satya K is a **static Jekyll blog with planned autonomous AI content 
 │ Author's Machine (Local Development)                        │
 │ ├── Create/edit Markdown posts in _posts/                  │
 │ ├── Run: npm run dev (Gulp + Jekyll + BrowserSync)        │
-│ ├── Preview at localhost:4000                             │
+│ ├── Preview at localhost:4000/learn-with-satya/           │
 │ ├── Commit & push                                         │
 │ └── (Planned) Run agent pipeline                         │
 │     └── Generate posts via Claude API                    │

--- a/docs/codebase/stack.md
+++ b/docs/codebase/stack.md
@@ -67,8 +67,8 @@
   - Manages Node.js dev dependencies (Gulp, Babel, etc.)
   - Scripts in `package.json`:
     - `npm run build` → `gulp build`
-    - `npm run serve` → `bundle exec jekyll serve`
-    - `npm run dev` → `gulp build && bundle exec jekyll serve`
+    - `npm run serve` → `bundle exec jekyll serve --baseurl /learn-with-satya`
+    - `npm run dev` → `gulp build && bundle exec jekyll serve --baseurl /learn-with-satya`
 
 ### 3. **Ruby & Gems**
 
@@ -141,7 +141,7 @@ npm run dev
 gulp build
 
 # Jekyll only (for testing)
-bundle exec jekyll serve
+bundle exec jekyll serve --baseurl /learn-with-satya
 
 # Production build
 JEKYLL_ENV=production bundle exec jekyll build

--- a/docs/content-creation-guide.md
+++ b/docs/content-creation-guide.md
@@ -117,8 +117,8 @@ mkdir -p assets/images/posts/{slug}
 
 ### 3. Local Preview
 ```bash
-bundle exec jekyll serve
-# Visit: http://127.0.0.1:4000/{category}/{slug}/
+bundle exec jekyll serve --baseurl /learn-with-satya
+# Visit: http://127.0.0.1:4000/learn-with-satya/{category}/{slug}/
 ```
 
 ### 4. Commit and Deploy
@@ -186,7 +186,7 @@ git push origin main
 
 # 6. Deploy
 # (After completing action items)
-bundle exec jekyll serve  # test
+bundle exec jekyll serve --baseurl /learn-with-satya  # test
 git add . && git commit -m "feat(ai): add transformer-architecture-explained"
 git push origin main
 ```

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   },
   "scripts": {
     "build": "gulp build",
-    "serve": "bundle exec jekyll serve",
-    "dev": "gulp build && bundle exec jekyll serve"
+    "serve": "bundle exec jekyll serve --baseurl /learn-with-satya",
+    "dev": "gulp build && bundle exec jekyll serve --baseurl /learn-with-satya"
   },
   "devDependencies": {
     "browser-sync": "^2.26.7",


### PR DESCRIPTION
Fixes #10

## Problem Solved
Fixed URL mismatch between local development and production environments.

**Before:**
- Local: localhost:4000/ (root)
- Production: https://srisatyalokesh.is-a.dev/learn-with-satya/ (with baseurl)
- Agents expected /learn-with-satya/ path locally but it didn't exist

**After:**  
- Local: localhost:4000/learn-with-satya/ (with baseurl)
- Production: https://srisatyalokesh.is-a.dev/learn-with-satya/ (same baseurl)
- Perfect consistency between environments

## Changes Made
- Updated all Jekyll serve commands to include --baseurl /learn-with-satya
- Modified package.json scripts (npm run serve, npm run dev)
- Updated documentation across 7 files in docs/ directory
- Added docs/LOCAL-DEVELOPMENT.md with normalized setup guide
- Updated Git workflow skill with correct local commands

## Testing
✅ Jekyll build passes with no errors
✅ All documentation references updated
✅ Package.json scripts now include baseurl flag
✅ Local setup guide created for new developers

## Impact
- Agents and local development now use consistent URLs
- No more confusion between local and production paths
- Easier testing of features that depend on baseurl
- Better development experience matching production exactly