### PR TITLE
fix: Replace unprocessed Liquid template syntax in progress links

### DIFF
--- a/assets/js/learning-progress-tracker.js
+++ b/assets/js/learning-progress-tracker.js
@@ -152,7 +152,7 @@
       buttonContainer.innerHTML = `
         <div style="font-size: 3rem; margin-bottom: 1rem;">✅</div>
         <h3 style="margin: 0 0 0.5rem 0; font-size: 1.5rem; color: #000000;">You've completed this post!</h3>
-        <p style="margin: 0; color: #374151;">Check your <a href="{{ site.baseurl }}/progress/" style="color: #dc2f02; text-decoration: underline;">learning progress</a></p>
+        <p style="margin: 0; color: #374151;">Check your <a href="/learn-with-satya/progress/" style="color: #dc2f02; text-decoration: underline;">learning progress</a></p>
       `;
     } else {
       buttonContainer.innerHTML = `
@@ -185,7 +185,7 @@
         container.innerHTML = `
           <div style="font-size: 3rem; margin-bottom: 1rem;">✅</div>
           <h3 style="margin: 0 0 0.5rem 0; font-size: 1.5rem; color: #000000;">Marked as complete!</h3>
-          <p style="margin: 0; color: #374151;">Check your <a href="{{ site.baseurl }}/progress/" style="color: #dc2f02; text-decoration: underline;">learning progress</a></p>
+          <p style="margin: 0; color: #374151;">Check your <a href="/learn-with-satya/progress/" style="color: #dc2f02; text-decoration: underline;">learning progress</a></p>
         `;
       }
     }, 100);


### PR DESCRIPTION
Fixes #12

## Problem
Learning progress completion messages contained unprocessed Liquid template syntax in JavaScript strings, which Jekyll cannot process. This resulted in malformed URLs with URL-encoded literal text.

## Solution  
- Replaced liquid templates with static /learn-with-satya/progress/ paths
- Updated both instances in learning-progress-tracker.js

## Testing
- Local build passes (1.506s, no errors)
- JavaScript syntax valid
- Progress notification links now resolve correctly