### PR TITLE
fix: Correct reading time parsing for post completion

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -204,7 +204,7 @@
                 category: '{{ page.category }}',
                 series: {% if page.series %}'{{ page.series }}'{% else %}null{% endif %},
                 part: {% if page.part %}{{ page.part }}{% else %}null{% endif %},
-                readingTime: {{ minutesText | replace: ' min read', '' | default: 5 }}
+                readingTime: parseInt('{{ minutesText | replace: ' min to read', '' | default: 5 }}') || 5
             };
         </script>
         <script src="{{ '/assets/js/learning-progress-tracker.js' | prepend: site.baseurl }}"></script>


### PR DESCRIPTION
Fixes #14

Reading time filter used wrong text. Changed from ' min read' (failed) to ' min to read' (correct).

Ensures:
- readingTime is number not string
- Post completion saves to localStorage
- Series tracking works properly