### PR TITLE
fix: Display footer menu links horizontally

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -22,7 +22,9 @@
       {% endif %}
     </p>
 
-    {% include links.html %}
+    <nav style="display: flex; gap: 1.5rem; justify-content: center; flex-wrap: wrap; margin: 1rem 0;">
+      {% include links.html %}
+    </nav>
 
     <p style="text-align: center;">
       <span>Learn@SatyaK</span> was made with <svg class="love"><use xlink:href="#icon-heart"></use></svg> by <a href="https://github.com/SriSatyaLokesh" target="_blank" class="creator">Satya K</a>

--- a/_includes/links.html
+++ b/_includes/links.html
@@ -1,7 +1,7 @@
-<ul>
+<ul style="list-style: none; display: flex; gap: 1.5rem; margin: 0; padding: 0; flex-wrap: wrap; justify-content: center;">
   {% for item in site.menu %}
     {% if item.title and item.url %}
-      <li>
+      <li style="margin: 0;">
         <a href="{{ site.url }}{{ site.baseurl }}{{ item.url }}">{{ item.title }}</a>
       </li>
     {% endif %}


### PR DESCRIPTION
Fixes #18

- Updated footer.html to wrap links in flex container
- Modified links.html to display ul/li items horizontally
- Menu items now align with social media icon layout
- Responsive with flex-wrap for mobile screens
- No console errors, build passes