### PR TITLE
fix: Add blank lines before markdown tables

### DIFF
--- a/_posts/tools/2026-03-20-copilot-cli-getting-started.md
+++ b/_posts/tools/2026-03-20-copilot-cli-getting-started.md
@@ -86,6 +86,7 @@ Interact with GitHub Copilot from the command line
 ```
 
 **Common setup errors:**
+
 | Error | Cause | Fix |
 |-------|-------|-----|
 | 'gh: command not found' | GitHub CLI not installed | Install with brew/winget/apt |

--- a/_posts/tools/2026-04-10-copilot-cli-advanced-usage.md
+++ b/_posts/tools/2026-04-10-copilot-cli-advanced-usage.md
@@ -88,6 +88,7 @@ my-merge-agent   ready
 ```
 
 **Common setup errors:**
+
 | Error | Cause | Fix |
 |-------|-------|-----|
 | 'agent not found' | Wrong path or filename | Check .github/agents/ |


### PR DESCRIPTION
Fixes #20

**Root cause:** Jekyll/Kramdown requires blank line before tables
**Fixed files:**
- copilot-cli-getting-started.md
- copilot-cli-advanced-usage.md

**Verification:**
- All 9 tables across 4 posts now have proper formatting
- Jekyll build passes (3.8s, no errors)
- Subagent audit confirms all tables render correctly