### PR TITLE
fix: Update all URLs to /learn-ai baseurl

### DIFF
--- a/.github/agents/formatter.agent.md
+++ b/.github/agents/formatter.agent.md
@@ -86,7 +86,7 @@ prerequisites:
 seo:
   primary_keyword: "{primary keyword from Phase 3}"
   secondary_keywords: [{secondary keywords from Phase 3}]
-  canonical_url: "https://yourusername.github.io/learn-with-satya/{category}/{slug}/"
+  canonical_url: "https://yourusername.github.io/learn-ai/{category}/{slug}/"
 ---
 ```
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -35,7 +35,7 @@ gh issue create --title "fix: Brief description" --body "Detailed description"
 # If 'gh' command not found, use full path:
 & "C:\Program Files\GitHub CLI\gh.exe" issue create --title "fix: Brief description" --body "Detailed description"
 
-# Returns: https://github.com/SriSatyaLokesh/learn-with-satya/issues/42
+# Returns: https://github.com/SriSatyaLokesh/learn-ai/issues/42
 ```
 
 **2. Create Feature Branch**
@@ -87,7 +87,7 @@ gh pr create `
 - Local build passes, no errors" `
   --base main
 
-# Returns: https://github.com/SriSatyaLokesh/learn-with-satya/pull/3
+# Returns: https://github.com/SriSatyaLokesh/learn-ai/pull/3
 ```
 
 **7. Assign Reviewer**

--- a/.github/skills/git-workflow-github-cli/SKILL.md
+++ b/.github/skills/git-workflow-github-cli/SKILL.md
@@ -144,8 +144,8 @@ bundle exec jekyll build --future
 # Exit code 1 = errors
 
 # Test with local server (optional)
-bundle exec jekyll serve --future --baseurl /learn-with-satya
-# Visit: http://127.0.0.1:4000/learn-with-satya/
+bundle exec jekyll serve --future --baseurl /learn-ai/
+# Visit: http://127.0.0.1:4000/learn-ai/
 ```
 
 ---

--- a/assets/js/learning-progress-tracker.js
+++ b/assets/js/learning-progress-tracker.js
@@ -152,7 +152,7 @@
       buttonContainer.innerHTML = `
         <div style="font-size: 3rem; margin-bottom: 1rem;">✅</div>
         <h3 style="margin: 0 0 0.5rem 0; font-size: 1.5rem; color: #000000;">You've completed this post!</h3>
-        <p style="margin: 0; color: #374151;">Check your <a href="/learn-with-satya/progress/" style="color: #dc2f02; text-decoration: underline;">learning progress</a></p>
+        <p style="margin: 0; color: #374151;">Check your <a href="{{site.baseurl}}/progress/" style="color: #dc2f02; text-decoration: underline;">learning progress</a></p>
       `;
     } else {
       buttonContainer.innerHTML = `
@@ -185,7 +185,7 @@
         container.innerHTML = `
           <div style="font-size: 3rem; margin-bottom: 1rem;">✅</div>
           <h3 style="margin: 0 0 0.5rem 0; font-size: 1.5rem; color: #000000;">Marked as complete!</h3>
-          <p style="margin: 0; color: #374151;">Check your <a href="/learn-with-satya/progress/" style="color: #dc2f02; text-decoration: underline;">learning progress</a></p>
+          <p style="margin: 0; color: #374151;">Check your <a href="{{site.baseurl}}/progress/" style="color: #dc2f02; text-decoration: underline;">learning progress</a></p>
         `;
       }
     }, 100);

--- a/docs/codebase/architecture.md
+++ b/docs/codebase/architecture.md
@@ -33,7 +33,7 @@ Learn with Satya K is a **static Jekyll blog with planned autonomous AI content 
 │ Author's Machine (Local Development)                        │
 │ ├── Create/edit Markdown posts in _posts/                  │
 │ ├── Run: npm run dev (Gulp + Jekyll + BrowserSync)        │
-│ ├── Preview at localhost:4000/learn-with-satya/           │
+│ ├── Preview at localhost:4000/learn-ai/           │
 │ ├── Commit & push                                         │
 │ └── (Planned) Run agent pipeline                         │
 │     └── Generate posts via Claude API                    │
@@ -46,7 +46,7 @@ Learn with Satya K is a **static Jekyll blog with planned autonomous AI content 
 ## Request Flow — User Accessing a Blog Post
 
 ```
-1. User navigates to: https://username.github.io/learn-with-satya/ai/transformer-architecture/
+1. User navigates to: https://username.github.io/learn-ai/ai/transformer-architecture/
 
 2. GitHub Pages serves pre-built HTML from _site/ (< 100ms, cached by CDN)
 

--- a/docs/codebase/conventions.md
+++ b/docs/codebase/conventions.md
@@ -39,12 +39,12 @@ permalink: /:categories/:title/
 
 **Generated URL:**
 ```
-https://yourusername.github.io/learn-with-satya/{category}/{slug}/
+https://yourusername.github.io/learn-ai/{category}/{slug}/
 ```
 
 **Examples:**
-- `https://yourusername.github.io/learn-with-satya/ai/transformer-architecture-explained/`
-- `https://yourusername.github.io/learn-with-satya/backend/rest-api-design-patterns/`
+- `https://yourusername.github.io/learn-ai/ai/transformer-architecture-explained/`
+- `https://yourusername.github.io/learn-ai/backend/rest-api-design-patterns/`
 
 ### Image Files
 
@@ -111,7 +111,7 @@ prerequisites:
 seo:
   primary_keyword: "transformer architecture explained"
   secondary_keywords: [self-attention mechanism, encoder-decoder architecture, BERT vs GPT, positional encoding]
-  canonical_url: "https://yourusername.github.io/learn-with-satya/ai/transformer-architecture-explained/"
+  canonical_url: "https://yourusername.github.io/learn-ai/ai/transformer-architecture-explained/"
 ---
 ```
 
@@ -140,7 +140,7 @@ seo:
 | `prerequisites` | Array | Optional | Array of `{title, url}` objects; links to required prior knowledge | See template above |
 | `seo.primary_keyword` | String | ✅ Yes | Main target keyword for SEO; used for Formatter validation | `transformer architecture explained` |
 | `seo.secondary_keywords` | Array | Optional | 4–6 related keywords for context; lower priority than primary | See template above |
-| `seo.canonical_url` | URL | ✅ Yes | Absolute canonical URL for this post; prevents duplicate content issues | `https://yourusername.github.io/learn-with-satya/ai/transformer-architecture-explained/` |
+| `seo.canonical_url` | URL | ✅ Yes | Absolute canonical URL for this post; prevents duplicate content issues | `https://yourusername.github.io/learn-ai/ai/transformer-architecture-explained/` |
 
 ---
 

--- a/docs/codebase/integrations.md
+++ b/docs/codebase/integrations.md
@@ -31,7 +31,7 @@
 1. Push to `main` branch
 2. GitHub Pages automatically detects Jekyll project
 3. Runs build via GitHub Actions
-4. Deploys static output to `https://username.github.io/learn-with-satya/`
+4. Deploys static output to `https://username.github.io/learn-ai/`
 
 **Configuration:**
 - Repo must be public (for free tier)


### PR DESCRIPTION
Fixes #26

- Replaced all /learn-with-satya/ URLs in source and docs
- Fixed navigation, progress, canonical, and documentation links
- Does not touch generated _site/ files
- Ensures all endpoints and docs use the new baseurl
- Local and remote tested